### PR TITLE
Phase 3: OCR Integration

### DIFF
--- a/DocboxKit/OCRProcessor.swift
+++ b/DocboxKit/OCRProcessor.swift
@@ -1,0 +1,101 @@
+import Foundation
+import CoreGraphics
+import Vision
+
+/// Represents recognized text with its position in the image
+public struct TextObservation: Equatable, Sendable {
+    /// The recognized text string
+    public let text: String
+
+    /// Bounding box in normalized coordinates (0.0-1.0), bottom-left origin
+    public let boundingBox: CGRect
+
+    /// Recognition confidence (0.0-1.0)
+    public let confidence: Float
+
+    public init(text: String, boundingBox: CGRect, confidence: Float) {
+        self.text = text
+        self.boundingBox = boundingBox
+        self.confidence = confidence
+    }
+}
+
+/// Performs optical character recognition on images using Vision framework
+public final class OCRProcessor {
+    /// Recognition accuracy level
+    public enum RecognitionLevel {
+        case fast
+        case accurate
+
+        var visionLevel: VNRequestTextRecognitionLevel {
+            switch self {
+            case .fast: return .fast
+            case .accurate: return .accurate
+            }
+        }
+    }
+
+    private let recognitionLevel: RecognitionLevel
+
+    /// Creates an OCRProcessor with the specified recognition level
+    /// - Parameter recognitionLevel: The accuracy level for text recognition (default: .accurate)
+    public init(recognitionLevel: RecognitionLevel = .accurate) {
+        self.recognitionLevel = recognitionLevel
+    }
+
+    /// Recognize text in an image
+    /// - Parameter image: The image to process
+    /// - Returns: Array of text observations with positions and confidence
+    public func recognize(_ image: CGImage) async throws -> [TextObservation] {
+        return try await withCheckedThrowingContinuation { continuation in
+            let handler = VNImageRequestHandler(cgImage: image, options: [:])
+
+            let request = VNRecognizeTextRequest { request, error in
+                if let error = error {
+                    continuation.resume(throwing: OCRError.recognitionFailed(error))
+                    return
+                }
+
+                guard let observations = request.results as? [VNRecognizedTextObservation] else {
+                    continuation.resume(returning: [])
+                    return
+                }
+
+                let textObservations = observations.compactMap { observation -> TextObservation? in
+                    guard let candidate = observation.topCandidates(1).first else {
+                        return nil
+                    }
+
+                    return TextObservation(
+                        text: candidate.string,
+                        boundingBox: observation.boundingBox,
+                        confidence: candidate.confidence
+                    )
+                }
+
+                continuation.resume(returning: textObservations)
+            }
+
+            request.recognitionLevel = recognitionLevel.visionLevel
+            request.usesLanguageCorrection = true
+
+            do {
+                try handler.perform([request])
+            } catch {
+                continuation.resume(throwing: OCRError.recognitionFailed(error))
+            }
+        }
+    }
+}
+
+/// Errors that can occur during OCR processing
+public enum OCRError: Error, LocalizedError {
+    case recognitionFailed(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .recognitionFailed(let error):
+            return "OCR recognition failed: \(error.localizedDescription)"
+        }
+    }
+}

--- a/DocboxKitTests/OCRProcessorTests.swift
+++ b/DocboxKitTests/OCRProcessorTests.swift
@@ -1,0 +1,200 @@
+import Testing
+import Foundation
+import CoreGraphics
+import CoreText
+@testable import DocboxKit
+
+@Suite("OCRProcessor Tests")
+struct OCRProcessorTests {
+
+    // MARK: - Helper
+
+    /// Create a test image with text rendered on it
+    private func createImageWithText(_ text: String, width: Int = 400, height: Int = 100) -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue)
+
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue
+        ) else {
+            fatalError("Failed to create test image context")
+        }
+
+        // Fill with white background
+        context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        // Draw text in black
+        context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+
+        let font = CTFontCreateWithName("Helvetica-Bold" as CFString, 36, nil)
+        let attributes: [CFString: Any] = [kCTFontAttributeName: font]
+        let attributedString = CFAttributedStringCreate(nil, text as CFString, attributes as CFDictionary)!
+        let line = CTLineCreateWithAttributedString(attributedString)
+
+        context.textPosition = CGPoint(x: 20, y: 30)
+        CTLineDraw(line, context)
+
+        return context.makeImage()!
+    }
+
+    /// Create an empty white image
+    private func createEmptyImage(width: Int = 400, height: Int = 100) -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue)
+
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue
+        ) else {
+            fatalError("Failed to create test image context")
+        }
+
+        // Fill with white
+        context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        return context.makeImage()!
+    }
+
+    // MARK: - Task 1.1: TextObservation initialization and properties
+
+    @Test("TextObservation initialization and properties")
+    func textObservationInitialization() {
+        let observation = TextObservation(
+            text: "Hello",
+            boundingBox: CGRect(x: 0.1, y: 0.2, width: 0.5, height: 0.1),
+            confidence: 0.95
+        )
+
+        #expect(observation.text == "Hello")
+        #expect(observation.boundingBox.origin.x == 0.1)
+        #expect(observation.boundingBox.origin.y == 0.2)
+        #expect(observation.boundingBox.width == 0.5)
+        #expect(observation.boundingBox.height == 0.1)
+        #expect(observation.confidence == 0.95)
+    }
+
+    // MARK: - Task 1.2: Bounding box normalization validation
+
+    @Test("bounding box normalization validation")
+    func boundingBoxNormalization() {
+        // Valid normalized coordinates (0.0-1.0)
+        let observation = TextObservation(
+            text: "Test",
+            boundingBox: CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0),
+            confidence: 1.0
+        )
+
+        // Bounding box should be within 0.0-1.0 range
+        #expect(observation.boundingBox.minX >= 0.0)
+        #expect(observation.boundingBox.minY >= 0.0)
+        #expect(observation.boundingBox.maxX <= 1.0)
+        #expect(observation.boundingBox.maxY <= 1.0)
+    }
+
+    // MARK: - Task 2.2: Empty image returns empty observations
+
+    @Test("empty image returns empty observations")
+    func emptyImageReturnsEmpty() async throws {
+        let processor = OCRProcessor(recognitionLevel: .fast)
+        let emptyImage = createEmptyImage()
+
+        let observations = try await processor.recognize(emptyImage)
+        #expect(observations.isEmpty)
+    }
+
+    // MARK: - Task 2.3: Recognition level configuration
+
+    @Test("recognition level configuration - fast")
+    func recognitionLevelFast() async throws {
+        let processor = OCRProcessor(recognitionLevel: .fast)
+        // Verify it can be instantiated and used with fast level
+        let emptyImage = createEmptyImage()
+        let observations = try await processor.recognize(emptyImage)
+        #expect(observations.isEmpty)
+    }
+
+    @Test("recognition level configuration - accurate")
+    func recognitionLevelAccurate() async throws {
+        let processor = OCRProcessor(recognitionLevel: .accurate)
+        // Verify it can be instantiated and used with accurate level
+        let emptyImage = createEmptyImage()
+        let observations = try await processor.recognize(emptyImage)
+        #expect(observations.isEmpty)
+    }
+
+    // MARK: - Task 2.1: Recognize text in image with known content
+
+    @Test("recognize text in image with known content")
+    func recognizeTextInImage() async throws {
+        let processor = OCRProcessor(recognitionLevel: .accurate)
+        let image = createImageWithText("HELLO")
+
+        let observations = try await processor.recognize(image)
+
+        // Should find at least one text observation
+        #expect(!observations.isEmpty)
+
+        // Should contain "HELLO" or similar (OCR might not be exact)
+        let foundText = observations.map { $0.text.uppercased() }.joined(separator: " ")
+        #expect(foundText.contains("HELLO") || foundText.contains("HELL") || foundText.contains("ELLO"))
+    }
+
+    // MARK: - Task 2.4: Bounding boxes are normalized (0.0-1.0)
+
+    @Test("bounding boxes are normalized")
+    func boundingBoxesNormalized() async throws {
+        let processor = OCRProcessor(recognitionLevel: .accurate)
+        let image = createImageWithText("TEST")
+
+        let observations = try await processor.recognize(image)
+
+        for observation in observations {
+            // All bounding box coordinates should be normalized (0.0-1.0)
+            #expect(observation.boundingBox.origin.x >= 0.0)
+            #expect(observation.boundingBox.origin.y >= 0.0)
+            #expect(observation.boundingBox.maxX <= 1.0)
+            #expect(observation.boundingBox.maxY <= 1.0)
+            #expect(observation.boundingBox.width > 0.0)
+            #expect(observation.boundingBox.height > 0.0)
+        }
+    }
+
+    // MARK: - TextObservation Equatable
+
+    @Test("TextObservation equatable conformance")
+    func textObservationEquatable() {
+        let obs1 = TextObservation(
+            text: "Hello",
+            boundingBox: CGRect(x: 0.1, y: 0.2, width: 0.5, height: 0.1),
+            confidence: 0.95
+        )
+
+        let obs2 = TextObservation(
+            text: "Hello",
+            boundingBox: CGRect(x: 0.1, y: 0.2, width: 0.5, height: 0.1),
+            confidence: 0.95
+        )
+
+        let obs3 = TextObservation(
+            text: "World",
+            boundingBox: CGRect(x: 0.1, y: 0.2, width: 0.5, height: 0.1),
+            confidence: 0.95
+        )
+
+        #expect(obs1 == obs2)
+        #expect(obs1 != obs3)
+    }
+}

--- a/stories/phase3-ocr-integration.md
+++ b/stories/phase3-ocr-integration.md
@@ -1,0 +1,150 @@
+# Phase 3: OCR Integration
+
+**Date:** 2026-01-21
+**Branch:** `phase3-ocr-integration`
+**Issue:** https://github.com/galexy/docbox/issues/4
+
+## Overview
+
+Complete the pipeline by adding text recognition and searchable PDF generation. This phase adds:
+- OCRProcessor class using Vision framework's VNRecognizeTextRequest
+- Invisible text layer in generated PDFs
+- Full searchable PDF output
+
+## Deliverables
+
+- OCRProcessor class
+- TextObservation type for OCR results
+- Updated PDFGenerator with text layer support
+- CLI integration with OCR pipeline
+
+## Detailed Design
+
+### TextObservation
+
+A value type representing recognized text with its position:
+
+```swift
+public struct TextObservation {
+    /// The recognized text string
+    public let text: String
+
+    /// Bounding box in normalized coordinates (0.0-1.0), bottom-left origin
+    public let boundingBox: CGRect
+
+    /// Recognition confidence (0.0-1.0)
+    public let confidence: Float
+}
+```
+
+### OCRProcessor
+
+Performs text recognition on images:
+
+```swift
+public final class OCRProcessor {
+    public enum RecognitionLevel {
+        case fast
+        case accurate
+    }
+
+    public init(recognitionLevel: RecognitionLevel = .accurate)
+
+    /// Recognize text in an image
+    /// - Parameter image: The image to process
+    /// - Returns: Array of text observations
+    public func recognize(_ image: CGImage) async throws -> [TextObservation]
+}
+```
+
+### Vision Framework Integration
+
+1. Create `VNImageRequestHandler` with the CGImage
+2. Create `VNRecognizeTextRequest` with recognition level
+3. Perform the request synchronously (wrapped in async)
+4. Extract `VNRecognizedTextObservation` results
+5. Convert to `TextObservation` with bounding boxes
+
+### PDFGenerator Text Layer
+
+Update PDFGenerator to accept text observations and draw invisible text:
+
+```swift
+public func addPage(_ image: CGImage, textObservations: [TextObservation] = [])
+```
+
+For each observation:
+1. Convert normalized bounding box to PDF points
+2. Calculate font size to approximately match text width
+3. Draw text with transparent fill color (alpha = 0)
+4. Use Helvetica font for consistent rendering
+
+### Coordinate Transformation
+
+Vision's normalized coordinates (0.0-1.0) to PDF points:
+```
+pdfX = boundingBox.origin.x * pageWidth
+pdfY = boundingBox.origin.y * pageHeight
+pdfWidth = boundingBox.width * pageWidth
+pdfHeight = boundingBox.height * pageHeight
+```
+
+Both use bottom-left origin, so no flip is needed.
+
+### CLI Integration
+
+Update scan pipeline:
+1. Scan image
+2. Run OCR on image (if outputting PDF)
+3. Add page with text observations to PDFGenerator
+
+```swift
+for await image in stream {
+    let observations = try await ocrProcessor.recognize(image)
+    pdfGenerator.addPage(image, textObservations: observations)
+}
+```
+
+## Tasks
+
+### Unit Tests
+
+#### 1. TextObservation Tests
+- [x] 1.1 TextObservation initialization and properties
+- [x] 1.2 Bounding box normalization validation
+
+#### 2. OCRProcessor Tests
+- [x] 2.1 Recognize text in image with known content
+- [x] 2.2 Empty image returns empty observations
+- [x] 2.3 Recognition level configuration (fast vs accurate)
+- [x] 2.4 Bounding boxes are normalized (0.0-1.0)
+
+#### 3. PDFGenerator Text Layer Tests
+- [x] 3.1 PDF with text layer is searchable
+- [x] 3.2 Text positions match observation bounding boxes
+- [x] 3.3 Text is invisible (doesn't affect visual appearance)
+- [x] 3.4 Multi-page PDF with text on each page
+
+### Implementation
+
+#### 4. TextObservation Type
+- [x] 4.1 Create TextObservation struct
+- [x] 4.2 Add text, boundingBox, confidence properties
+
+#### 5. OCRProcessor Class
+- [x] 5.1 Create OCRProcessor in DocboxKit
+- [x] 5.2 Implement VNRecognizeTextRequest setup
+- [x] 5.3 Implement async recognize method
+- [x] 5.4 Extract observations from VNRecognizedTextObservation
+- [x] 5.5 Support fast/accurate recognition levels
+
+#### 6. PDFGenerator Updates
+- [x] 6.1 Update addPage to accept text observations
+- [x] 6.2 Implement coordinate transformation
+- [x] 6.3 Calculate font size from bounding box
+- [x] 6.4 Draw invisible text layer
+
+#### 7. CLI Updates
+- [x] 7.1 Integrate OCR into PDF scan pipeline
+- [x] 7.2 Add --no-ocr flag to skip text recognition
+- [x] 7.3 Update help text and documentation


### PR DESCRIPTION
## Summary

- Add `OCRProcessor` class using Vision framework's `VNRecognizeTextRequest` for text recognition
- Add `TextObservation` type to represent recognized text with bounding boxes and confidence
- Update `PDFGenerator` to draw invisible text layer for searchable PDFs using CoreText
- Integrate OCR into CLI scan pipeline with `--no-ocr` flag to skip text recognition

Closes #4

## Test plan

- [x] All unit tests pass (60+ tests)
- [x] `OCRProcessorTests` verify text recognition, bounding box normalization, recognition levels
- [x] `PDFGeneratorTests` verify searchable text layer, text positions, multi-page support
- [x] Manual test: scan document to PDF and verify text is searchable in Preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)