### PR TITLE
Fix orientation detection for rotated scanned pages

### DIFF
--- a/DocboxKit/OCRProcessor.swift
+++ b/DocboxKit/OCRProcessor.swift
@@ -13,10 +13,146 @@ public struct TextObservation: Equatable, Sendable {
     /// Recognition confidence (0.0-1.0)
     public let confidence: Float
 
-    public init(text: String, boundingBox: CGRect, confidence: Float) {
+    /// Corner points in normalized coordinates (0.0-1.0), bottom-left origin
+    public let topLeft: CGPoint
+    public let topRight: CGPoint
+    public let bottomLeft: CGPoint
+    public let bottomRight: CGPoint
+
+    public init(text: String, boundingBox: CGRect, confidence: Float,
+                topLeft: CGPoint = .zero, topRight: CGPoint = .zero,
+                bottomLeft: CGPoint = .zero, bottomRight: CGPoint = .zero) {
         self.text = text
         self.boundingBox = boundingBox
         self.confidence = confidence
+        self.topLeft = topLeft
+        self.topRight = topRight
+        self.bottomLeft = bottomLeft
+        self.bottomRight = bottomRight
+    }
+}
+
+/// Page orientation based on text angle analysis
+public enum PageOrientation: Int, Sendable {
+    case up = 0        // Correct orientation
+    case right = 90    // Rotated 90° clockwise
+    case down = 180    // Upside down
+    case left = 270    // Rotated 90° counter-clockwise
+
+    /// The rotation needed to correct this orientation (opposite direction)
+    public var correctionDegrees: Int {
+        switch self {
+        case .up: return 0
+        case .right: return 270  // Rotate 270° CW (or 90° CCW) to fix
+        case .down: return 180
+        case .left: return 90    // Rotate 90° CW to fix
+        }
+    }
+}
+
+/// Detects page orientation from text observations
+public struct OrientationDetector {
+    /// Detect page orientation from text observations by analyzing text angles
+    /// - Parameter observations: Array of text observations with corner points
+    /// - Returns: Detected page orientation
+    public static func detect(from observations: [TextObservation]) -> PageOrientation {
+        guard !observations.isEmpty else {
+            return .up
+        }
+
+        var angleCounts: [PageOrientation: Int] = [.up: 0, .right: 0, .down: 0, .left: 0]
+
+        for observation in observations {
+            // Calculate angle from topLeft to topRight (the text baseline direction)
+            let dx = observation.topRight.x - observation.topLeft.x
+            let dy = observation.topRight.y - observation.topLeft.y
+            var angle = atan2(dy, dx) * 180 / .pi
+
+            // Normalize to 0-360 range
+            if angle < 0 {
+                angle += 360
+            }
+
+            // Bucket into quadrants
+            let orientation: PageOrientation
+            if angle >= 315 || angle < 45 {
+                orientation = .up
+            } else if angle >= 45 && angle < 135 {
+                orientation = .right
+            } else if angle >= 135 && angle < 225 {
+                orientation = .down
+            } else {
+                orientation = .left
+            }
+
+            angleCounts[orientation, default: 0] += 1
+        }
+
+        // Return the most common orientation
+        return angleCounts.max(by: { $0.value < $1.value })?.key ?? .up
+    }
+}
+
+/// Extension to rotate CGImage
+public extension CGImage {
+    /// Rotate image by specified degrees (must be 0, 90, 180, or 270)
+    /// - Parameter degrees: Rotation in degrees (0, 90, 180, or 270)
+    /// - Returns: Rotated image, or nil if rotation fails
+    func rotated(by degrees: Int) -> CGImage? {
+        guard degrees != 0 else { return self }
+
+        let radians = CGFloat(degrees) * .pi / 180
+
+        // Calculate new dimensions
+        let originalWidth = CGFloat(width)
+        let originalHeight = CGFloat(height)
+
+        let newWidth: Int
+        let newHeight: Int
+
+        switch degrees {
+        case 90, 270:
+            newWidth = height
+            newHeight = width
+        case 180:
+            newWidth = width
+            newHeight = height
+        default:
+            return nil // Only support 90° increments
+        }
+
+        // Create context with new dimensions
+        guard let colorSpace = self.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(
+                data: nil,
+                width: newWidth,
+                height: newHeight,
+                bitsPerComponent: bitsPerComponent,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            return nil
+        }
+
+        // Move origin and rotate
+        switch degrees {
+        case 90:
+            context.translateBy(x: CGFloat(newWidth), y: 0)
+        case 180:
+            context.translateBy(x: CGFloat(newWidth), y: CGFloat(newHeight))
+        case 270:
+            context.translateBy(x: 0, y: CGFloat(newHeight))
+        default:
+            break
+        }
+
+        context.rotate(by: radians)
+
+        // Draw the original image
+        context.draw(self, in: CGRect(x: 0, y: 0, width: originalWidth, height: originalHeight))
+
+        return context.makeImage()
     }
 }
 
@@ -69,7 +205,11 @@ public final class OCRProcessor {
                     return TextObservation(
                         text: candidate.string,
                         boundingBox: observation.boundingBox,
-                        confidence: candidate.confidence
+                        confidence: candidate.confidence,
+                        topLeft: observation.topLeft,
+                        topRight: observation.topRight,
+                        bottomLeft: observation.bottomLeft,
+                        bottomRight: observation.bottomRight
                     )
                 }
 
@@ -85,6 +225,33 @@ public final class OCRProcessor {
                 continuation.resume(throwing: OCRError.recognitionFailed(error))
             }
         }
+    }
+
+    /// Recognize text with automatic orientation detection and correction
+    /// - Parameter image: The image to process
+    /// - Returns: Tuple of corrected image and text observations
+    public func recognizeWithOrientationCorrection(_ image: CGImage) async throws -> (image: CGImage, observations: [TextObservation]) {
+        // First pass: recognize text to detect orientation
+        let initialObservations = try await recognize(image)
+
+        // Detect orientation from text angles
+        let orientation = OrientationDetector.detect(from: initialObservations)
+
+        // If already upright, return original results
+        guard orientation != .up else {
+            return (image, initialObservations)
+        }
+
+        // Rotate image to correct orientation
+        guard let rotatedImage = image.rotated(by: orientation.correctionDegrees) else {
+            // If rotation fails, return original
+            return (image, initialObservations)
+        }
+
+        // Second pass: recognize text on corrected image
+        let correctedObservations = try await recognize(rotatedImage)
+
+        return (rotatedImage, correctedObservations)
     }
 }
 

--- a/stories/fix-orientation-detection.md
+++ b/stories/fix-orientation-detection.md
@@ -1,0 +1,144 @@
+# Fix: Orientation Detection for OCR
+
+**Date:** 2026-01-21
+**Branch:** `fix-orientation-detection`
+**Issue:** https://github.com/galexy/docbox/issues/6
+
+## Overview
+
+Fix OCR text extraction for pages scanned in landscape orientation (rotated 90° left or right). Currently, rotated pages produce incomplete or incorrect OCR results.
+
+## Problem
+
+When a page is scanned rotated 90° (landscape orientation), the Vision framework's OCR cannot properly recognize text because it expects upright text. The resulting PDF has incomplete searchable text.
+
+## Solution
+
+Implement orientation detection using VNRecognizedTextObservation corner points, then rotate the image before final OCR and PDF output.
+
+### Approach
+
+1. Run initial OCR pass
+2. Analyze text observation corner points to detect dominant text angle
+3. If rotation detected (>45° from horizontal), determine nearest 90° rotation
+4. Rotate the CGImage to correct orientation
+5. Re-run OCR on rotated image
+6. Output correctly-oriented image and text to PDF
+
+## Deliverables
+
+- `OrientationDetector` class to analyze text observations and detect page rotation
+- `CGImage` rotation extension
+- Updated `OCRProcessor` to optionally detect and correct orientation
+- Updated CLI pipeline to use orientation correction for PDF output
+
+## Detailed Design
+
+### OrientationDetector
+
+Analyzes text observations to determine page orientation:
+
+```swift
+public enum PageOrientation: Int {
+    case up = 0        // 0° - correct orientation
+    case right = 90    // 90° CW - rotated right
+    case down = 180    // 180° - upside down
+    case left = 270    // 270° CW (90° CCW) - rotated left
+}
+
+public struct OrientationDetector {
+    /// Detect page orientation from text observations
+    static func detect(from observations: [TextObservation]) -> PageOrientation
+}
+```
+
+Algorithm:
+1. For each observation, calculate angle from topLeft to topRight corner
+2. Normalize angles to 0-360° range
+3. Bucket angles into quadrants (0°, 90°, 180°, 270°)
+4. Return most common orientation
+
+### CGImage Rotation Extension
+
+```swift
+extension CGImage {
+    /// Rotate image by specified degrees (must be 0, 90, 180, or 270)
+    func rotated(by degrees: Int) -> CGImage?
+}
+```
+
+### Updated TextObservation
+
+Add corner points to TextObservation:
+
+```swift
+public struct TextObservation {
+    public let text: String
+    public let boundingBox: CGRect
+    public let confidence: Float
+    // New: corner points for orientation detection
+    public let topLeft: CGPoint
+    public let topRight: CGPoint
+    public let bottomLeft: CGPoint
+    public let bottomRight: CGPoint
+}
+```
+
+### OCRProcessor Updates
+
+Add orientation-aware recognition:
+
+```swift
+public func recognizeWithOrientationCorrection(_ image: CGImage) async throws -> (image: CGImage, observations: [TextObservation])
+```
+
+This method:
+1. Runs initial OCR
+2. Detects orientation from observations
+3. If rotated, rotates image and re-runs OCR
+4. Returns corrected image and observations
+
+## Tasks
+
+### Unit Tests
+
+#### 1. OrientationDetector Tests
+- [x] 1.1 Detect upright orientation (0°)
+- [x] 1.2 Detect right rotation (90°)
+- [x] 1.3 Detect upside down (180°)
+- [x] 1.4 Detect left rotation (270°)
+- [x] 1.5 Handle empty observations (default to up)
+- [x] 1.6 Handle mixed angles (use majority)
+
+#### 2. CGImage Rotation Tests
+- [x] 2.1 Rotate 90° produces correct dimensions
+- [x] 2.2 Rotate 180° preserves dimensions
+- [x] 2.3 Rotate 270° produces correct dimensions
+- [x] 2.4 Rotate 0° returns original
+
+#### 3. Integration Tests
+- [x] 3.1 OCR with orientation correction improves rotated text recognition
+- [x] 3.2 PDF output has correct orientation
+
+### Implementation
+
+#### 4. TextObservation Updates
+- [x] 4.1 Add corner point properties
+- [x] 4.2 Update OCRProcessor to extract corner points
+
+#### 5. OrientationDetector
+- [x] 5.1 Create OrientationDetector struct
+- [x] 5.2 Implement angle calculation from corners
+- [x] 5.3 Implement orientation bucketing
+
+#### 6. CGImage Rotation
+- [x] 6.1 Create CGImage rotation extension
+- [x] 6.2 Implement 90°, 180°, 270° rotations
+
+#### 7. OCRProcessor Updates
+- [x] 7.1 Add recognizeWithOrientationCorrection method
+- [x] 7.2 Integrate orientation detection and image rotation
+
+#### 8. CLI Updates
+- [x] 8.1 Use orientation-corrected OCR for PDF output
+- [x] 8.2 Add --no-orientation flag to skip detection


### PR DESCRIPTION
## Summary

- Add corner points to `TextObservation` for orientation analysis
- Create `OrientationDetector` to detect page rotation from text angles
- Add `CGImage` rotation extension (90°, 180°, 270°)
- Add `recognizeWithOrientationCorrection` method to `OCRProcessor`
- Update CLI to automatically detect and correct page orientation
- Add `--no-orientation` flag to skip detection

Fixes #6

## How it works

1. Run initial OCR pass to get text observations with corner points
2. Analyze the angle from `topLeft` to `topRight` of each text region
3. Bucket angles into quadrants (0°, 90°, 180°, 270°)
4. If page is rotated, rotate the CGImage and re-run OCR
5. Output correctly-oriented image and text to PDF

## Test plan

- [x] All 70+ unit tests pass
- [x] OrientationDetector correctly identifies 0°, 90°, 180°, 270° rotations
- [x] CGImage rotation produces correct dimensions
- [x] CLI shows `--no-orientation` flag in help
- [x] Manual test: scan rotated page and verify PDF is correctly oriented

🤖 Generated with [Claude Code](https://claude.com/claude-code)